### PR TITLE
Assembler does not understand optimizer flags

### DIFF
--- a/build/marble.conf
+++ b/build/marble.conf
@@ -37,9 +37,6 @@ $(info $(OCD_CONF))
 ROM_SIZE      := 256K
 RAM_SIZE      := 128K
 
-# Compilation Flags
-FLAGS         := -g3 -ggdb
-
 # User Flags
 ## XRP_AUTOBOOT - Allow XRP to be enabled from RAM if no power channels are detected upon power up
 USR_CFLAGS    := -DMARBLE_STM32F207 -DMARBLE_V2 -DXRP_AUTOBOOT

--- a/build/marble_mini.conf
+++ b/build/marble_mini.conf
@@ -30,9 +30,6 @@ OCD_CONF      := lpc1776.cfg
 ROM_SIZE      := 256K
 RAM_SIZE      := 64K
 
-# Compilation Flags
-FLAGS         := -g3 -ggdb
-
 # User Flags
 ## XRP_AUTOBOOT - Allow XRP to be enabled from RAM if no power channels are detected upon power up
 USR_CFLAGS    := -DMARBLE_LPC1776 -DMARBLEM_V1 -DXRP_AUTOBOOT

--- a/makefile.board
+++ b/makefile.board
@@ -82,19 +82,24 @@ GDB=gdb-multiarch
 #
 OPENOCD         = openocd
 
+# binutils assembler does not accept the same set of arguments as gcc
+# https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html
+# https://sourceware.org/binutils/docs/as.html#Invoking
+AS_OPT_FLAGS ?= -g
+OPT_FLAGS ?= -g3 -ggdb
 
 # Compilation Flags
 #
 # Display all warnings. Compile functions and data into their own sections so
 # they can be discarded if unused.  The linker performs garbage collection of
 # unused input sections.
-CFLAGS = $(FLAGS) -Os -std=c11 -ffunction-sections -fdata-sections $(ARCH_FLAGS) $(USR_CFLAGS)
+CFLAGS = $(OPT_FLAGS) -Os -std=c11 -ffunction-sections -fdata-sections $(ARCH_FLAGS) $(USR_CFLAGS)
 CFLAGS += -Wall -Wextra -Wundef -Wshadow -Wstrict-prototypes -Wwrite-strings -pedantic
 CFLAGS += -Wpointer-arith -Wredundant-decls -Wunreachable-code
 # to do:  -Wcast-align -Wcast-qual
 
-ASFLAGS = $(FLAGS) $(ARCH_FLAGS)
-LDFLAGS = $(FLAGS) $(LINKER_FLAGS) -Wextra $(ARCH_FLAGS)
+ASFLAGS = $(AS_OPT_FLAGS) $(ARCH_FLAGS)
+LDFLAGS = $(OPT_FLAGS) $(LINKER_FLAGS) -Wextra $(ARCH_FLAGS)
 
 # Default target
 all: $(OUTPUT_DIR)/$(PROJECT_NAME).elf

--- a/makefile.sim
+++ b/makefile.sim
@@ -58,15 +58,21 @@ GCC_BASE_FLAGS += -Wextra -Wundef -Wshadow -Wstrict-prototypes -Wwrite-strings
 GCC_BASE_FLAGS += -Wpointer-arith -Wredundant-decls -Wunreachable-code
 # to do:  -Wcast-align -Wcast-qual
 
+# binutils assembler does not accept the same set of arguments as gcc
+# https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html
+# https://sourceware.org/binutils/docs/as.html#Invoking
+AS_OPT_FLAGS ?= -g
+OPT_FLAGS ?= -g3 -ggdb
+
 # Compilation Flags
 #
 # Display all warnings. Compile functions and data into their own sections so
 # they can be discarded if unused.  The linker performs garbage collection of
 # unused input sections.
-CFLAGS = $(FLAGS) -Os $(GCC_BASE_FLAGS) -Wno-unused-parameter -ffunction-sections -fdata-sections $(ARCH_FLAGS) $(USR_CFLAGS)
+CFLAGS = $(OPT_FLAGS) -Os $(GCC_BASE_FLAGS) -Wno-unused-parameter -ffunction-sections -fdata-sections $(ARCH_FLAGS) $(USR_CFLAGS)
 
-ASFLAGS = $(FLAGS) $(ARCH_FLAGS)
-LDFLAGS = $(FLAGS) $(LINKER_FLAGS) -Wextra $(ARCH_FLAGS)
+ASFLAGS = $(AS_OPT_FLAGS) $(ARCH_FLAGS)
+LDFLAGS = $(OPT_FLAGS) $(LINKER_FLAGS) -Wextra $(ARCH_FLAGS)
 
 # Default target
 all: $(OUTPUT_DIR)/$(PROJECT_NAME)


### PR DESCRIPTION
The binutils assembler does not accept the same set of arguments as gcc, so keep them in different Make variables.  These seem unlikely to be target specific, so move out of board/*.conf .

As a future effort, it might be worth exploring using the assembler through the gcc front-end, which might be smart enough to translate the `-g` arguments automatically.